### PR TITLE
Removed methods deprecated in GDAL3.6 (MINOR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ It was also updated to support gdal 3.x, while the older version wouldn't work o
 ## Installation
 
 1) go get github.com/seerai/godal
-2) install libgdal-dev 3.5+
+2) install libgdal-dev 3.6+
     - See [gdal's installation documentation for more details](https://gdal.org/download.html#). Note that many repos are not updated to 3.5 yet in which case there are [instructions for building from source](https://gdal.org/download.html#build-instructions).
 3) go build 
 
 
 ## Compatibility
 
-This software has been tested most recently on Ubuntu 20.04 with gdal 3.5
+This software has been tested most recently on Ubuntu 20.04 with gdal 3.6
 
 ## Examples
 

--- a/gdal.go
+++ b/gdal.go
@@ -1641,8 +1641,7 @@ func VSIFileFromMemBuffer(filename string, data []byte, takeOwnership bool) (VSI
 	return VSIFile{file}, nil
 }
 
-// Set a credential (or more generally an option related to a virtual file system) for a given path prefix.
-func VSISetCredential(path string, key string, value string) {
+func VSISetPathSpecificOption(path string, key string, value string) {
 
 	cPath := C.CString(path)
 	cKey := C.CString(key)
@@ -1653,15 +1652,14 @@ func VSISetCredential(path string, key string, value string) {
 		C.free(unsafe.Pointer(cValue))
 	}()
 
-	C.VSISetCredential(cPath, cKey, cValue)
+	C.VSISetPathSpecificOption(cPath, cKey, cValue)
 }
 
-// Clear credentials set with VSISetCredential()
-func VSIClearCredentials(path string) {
+func VSIClearPathSpecificOption(path string) {
 	cPath := C.CString(path)
 	defer C.free(unsafe.Pointer(cPath))
 
-	C.VSIClearCredentials(cPath)
+	C.VSIClearPathSpecificOptions(cPath)
 }
 
 /*


### PR DESCRIPTION
 - Removed the usage of VSISetCredential and VSIClearCredential that have been deprecated in GDAL 3.6