### PR TITLE
Updated to work with Go 1.21

### DIFF
--- a/algorithms.go
+++ b/algorithms.go
@@ -94,12 +94,14 @@ func (src RasterBand) ComputeProximity(
 	}
 	opts[length] = (*C.char)(unsafe.Pointer(nil))
 
-	return C.GDALComputeProximity(
-		src.cval,
-		dest.cval,
-		(**C.char)(unsafe.Pointer(&opts[0])),
-		C.goGDALProgressFuncProxyB(),
-		unsafe.Pointer(arg),
+	return CPLErr(
+		C.GDALComputeProximity(
+			src.cval,
+			dest.cval,
+			(**C.char)(unsafe.Pointer(&opts[0])),
+			C.goGDALProgressFuncProxyB(),
+			unsafe.Pointer(arg),
+		),
 	).Err()
 }
 
@@ -124,15 +126,17 @@ func (src RasterBand) FillNoData(
 	}
 	opts[length] = (*C.char)(unsafe.Pointer(nil))
 
-	return C.GDALFillNodata(
-		src.cval,
-		mask.cval,
-		C.double(distance),
-		0,
-		C.int(iterations),
-		(**C.char)(unsafe.Pointer(&opts[0])),
-		C.goGDALProgressFuncProxyB(),
-		unsafe.Pointer(arg),
+	return CPLErr(
+		C.GDALFillNodata(
+			src.cval,
+			mask.cval,
+			C.double(distance),
+			0,
+			C.int(iterations),
+			(**C.char)(unsafe.Pointer(&opts[0])),
+			C.goGDALProgressFuncProxyB(),
+			unsafe.Pointer(arg),
+		),
 	).Err()
 }
 
@@ -157,14 +161,16 @@ func (src RasterBand) Polygonize(
 	}
 	opts[length] = (*C.char)(unsafe.Pointer(nil))
 
-	return C.GDALPolygonize(
-		src.cval,
-		mask.cval,
-		layer.cval,
-		C.int(fieldIndex),
-		(**C.char)(unsafe.Pointer(&opts[0])),
-		C.goGDALProgressFuncProxyB(),
-		unsafe.Pointer(arg),
+	return CPLErr(
+		C.GDALPolygonize(
+			src.cval,
+			mask.cval,
+			layer.cval,
+			C.int(fieldIndex),
+			(**C.char)(unsafe.Pointer(&opts[0])),
+			C.goGDALProgressFuncProxyB(),
+			unsafe.Pointer(arg),
+		),
 	).Err()
 }
 
@@ -189,14 +195,16 @@ func (src RasterBand) FPolygonize(
 	}
 	opts[length] = (*C.char)(unsafe.Pointer(nil))
 
-	return C.GDALFPolygonize(
-		src.cval,
-		mask.cval,
-		layer.cval,
-		C.int(fieldIndex),
-		(**C.char)(unsafe.Pointer(&opts[0])),
-		C.goGDALProgressFuncProxyB(),
-		unsafe.Pointer(arg),
+	return CPLErr(
+		C.GDALFPolygonize(
+			src.cval,
+			mask.cval,
+			layer.cval,
+			C.int(fieldIndex),
+			(**C.char)(unsafe.Pointer(&opts[0])),
+			C.goGDALProgressFuncProxyB(),
+			unsafe.Pointer(arg),
+		),
 	).Err()
 }
 
@@ -220,15 +228,17 @@ func (src RasterBand) SieveFilter(
 	}
 	opts[length] = (*C.char)(unsafe.Pointer(nil))
 
-	return C.GDALSieveFilter(
-		src.cval,
-		mask.cval,
-		dest.cval,
-		C.int(threshold),
-		C.int(connectedness),
-		(**C.char)(unsafe.Pointer(&opts[0])),
-		C.goGDALProgressFuncProxyB(),
-		unsafe.Pointer(arg),
+	return CPLErr(
+		C.GDALSieveFilter(
+			src.cval,
+			mask.cval,
+			dest.cval,
+			C.int(threshold),
+			C.int(connectedness),
+			(**C.char)(unsafe.Pointer(&opts[0])),
+			C.goGDALProgressFuncProxyB(),
+			unsafe.Pointer(arg),
+		),
 	).Err()
 }
 

--- a/dataset.go
+++ b/dataset.go
@@ -82,10 +82,12 @@ func (dataset Dataset) AddBand(dataType DataType, options []string) error {
 	}
 	cOptions[length] = (*C.char)(unsafe.Pointer(nil))
 
-	return C.GDALAddBand(
-		dataset.cval,
-		C.GDALDataType(dataType),
-		(**C.char)(unsafe.Pointer(&cOptions[0])),
+	return CPLErr(
+		C.GDALAddBand(
+			dataset.cval,
+			C.GDALDataType(dataType),
+			(**C.char)(unsafe.Pointer(&cOptions[0])),
+		),
 	).Err()
 }
 
@@ -164,16 +166,18 @@ func (dataset Dataset) IO(
 		}
 	}
 
-	return C.GDALDatasetRasterIO(
-		dataset.cval,
-		C.GDALRWFlag(rwFlag),
-		C.int(xOff), C.int(yOff), C.int(xSize), C.int(ySize),
-		dataPtr,
-		C.int(bufXSize), C.int(bufYSize),
-		C.GDALDataType(dataType),
-		C.int(bandCount),
-		(*C.int)(unsafe.Pointer(&IntSliceToCInt(bandMap)[0])),
-		C.int(pixelSpace), C.int(lineSpace), C.int(bandSpace),
+	return CPLErr(
+		C.GDALDatasetRasterIO(
+			dataset.cval,
+			C.GDALRWFlag(rwFlag),
+			C.int(xOff), C.int(yOff), C.int(xSize), C.int(ySize),
+			dataPtr,
+			C.int(bufXSize), C.int(bufYSize),
+			C.GDALDataType(dataType),
+			C.int(bandCount),
+			(*C.int)(unsafe.Pointer(&IntSliceToCInt(bandMap)[0])),
+			C.int(pixelSpace), C.int(lineSpace), C.int(bandSpace),
+		),
 	).Err()
 }
 
@@ -246,14 +250,16 @@ func (dataset Dataset) AdviseRead(
 	}
 	cOptions[length] = (*C.char)(unsafe.Pointer(nil))
 
-	return C.GDALDatasetAdviseRead(
-		dataset.cval,
-		C.int(xOff), C.int(yOff), C.int(xSize), C.int(ySize),
-		C.int(bufXSize), C.int(bufYSize),
-		C.GDALDataType(dataType),
-		C.int(bandCount),
-		(*C.int)(unsafe.Pointer(&IntSliceToCInt(bandMap)[0])),
-		(**C.char)(unsafe.Pointer(&cOptions[0])),
+	return CPLErr(
+		C.GDALDatasetAdviseRead(
+			dataset.cval,
+			C.int(xOff), C.int(yOff), C.int(xSize), C.int(ySize),
+			C.int(bufXSize), C.int(bufYSize),
+			C.GDALDataType(dataType),
+			C.int(bandCount),
+			(*C.int)(unsafe.Pointer(&IntSliceToCInt(bandMap)[0])),
+			(**C.char)(unsafe.Pointer(&cOptions[0])),
+		),
 	).Err()
 }
 
@@ -268,7 +274,7 @@ func (dataset Dataset) SetProjection(proj string) error {
 	cProj := C.CString(proj)
 	defer C.free(unsafe.Pointer(cProj))
 
-	return C.GDALSetProjection(dataset.cval, cProj).Err()
+	return CPLErr(C.GDALSetProjection(dataset.cval, cProj)).Err()
 }
 
 // GeoTransform gets the affine transformation coefficients
@@ -280,9 +286,11 @@ func (dataset Dataset) GeoTransform() [6]float64 {
 
 // SetGeoTransform sets the affine transformation coefficients
 func (dataset Dataset) SetGeoTransform(transform [6]float64) error {
-	return C.GDALSetGeoTransform(
-		dataset.cval,
-		(*C.double)(unsafe.Pointer(&transform[0])),
+	return CPLErr(
+		C.GDALSetGeoTransform(
+			dataset.cval,
+			(*C.double)(unsafe.Pointer(&transform[0])),
+		),
 	).Err()
 }
 
@@ -344,15 +352,17 @@ func (dataset Dataset) BuildOverviews(
 
 	arg := &goGDALProgressFuncProxyArgs{progress, data}
 
-	return C.GDALBuildOverviews(
-		dataset.cval,
-		cResampling,
-		C.int(nOverviews),
-		(*C.int)(unsafe.Pointer(&IntSliceToCInt(overviewList)[0])),
-		C.int(nBands),
-		(*C.int)(unsafe.Pointer(&IntSliceToCInt(bandList)[0])),
-		C.goGDALProgressFuncProxyB(),
-		unsafe.Pointer(arg),
+	return CPLErr(
+		C.GDALBuildOverviews(
+			dataset.cval,
+			cResampling,
+			C.int(nOverviews),
+			(*C.int)(unsafe.Pointer(&IntSliceToCInt(overviewList)[0])),
+			C.int(nBands),
+			(*C.int)(unsafe.Pointer(&IntSliceToCInt(bandList)[0])),
+			C.goGDALProgressFuncProxyB(),
+			unsafe.Pointer(arg),
+		),
 	).Err()
 }
 
@@ -372,7 +382,7 @@ func (dataset Dataset) FlushCache() {
 
 // CreateMaskBand adds a mask band to the dataset
 func (dataset Dataset) CreateMaskBand(flags int) error {
-	return C.GDALCreateDatasetMaskBand(dataset.cval, C.int(flags)).Err()
+	return CPLErr(C.GDALCreateDatasetMaskBand(dataset.cval, C.int(flags))).Err()
 }
 
 // CopyWholeRaster copies all dataset raster data
@@ -392,11 +402,13 @@ func (sourceDataset Dataset) CopyWholeRaster(
 	}
 	cOptions[length] = (*C.char)(unsafe.Pointer(nil))
 
-	return C.GDALDatasetCopyWholeRaster(
-		sourceDataset.cval,
-		destDataset.cval,
-		(**C.char)(unsafe.Pointer(&cOptions[0])),
-		C.goGDALProgressFuncProxyB(),
-		unsafe.Pointer(arg),
+	return CPLErr(
+		C.GDALDatasetCopyWholeRaster(
+			sourceDataset.cval,
+			destDataset.cval,
+			(**C.char)(unsafe.Pointer(&cOptions[0])),
+			C.goGDALProgressFuncProxyB(),
+			unsafe.Pointer(arg),
+		),
 	).Err()
 }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/seerai/godal
 
 go 1.19
 
-require github.com/stretchr/testify v1.8.0
+require (
+	github.com/stretchr/testify v1.8.1
+	github.com/twpayne/go-geom v1.5.2
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -5,9 +6,13 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/twpayne/go-geom v1.5.2 h1:LyRfBX2W0LM7XN/bGqX0XxrJ7SZc3XwmxU4aj4kSoxw=
+github.com/twpayne/go-geom v1.5.2/go.mod h1:3z6O2sAnGtGCXx4Q+5nPOLCA5e8WI2t3cthdb1P2HH8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/ogr.go
+++ b/ogr.go
@@ -203,8 +203,10 @@ type Geometry struct {
 func CreateFromWKB(wkb []uint8, srs SpatialReference, bytes int) (Geometry, error) {
 	pabyData := (unsafe.Pointer(&wkb[0]))
 	var newGeom Geometry
-	return newGeom, C.OGR_G_CreateFromWkb(
-		pabyData, srs.cval, &newGeom.cval, C.int(bytes),
+	return newGeom, OGRErr(
+		C.OGR_G_CreateFromWkb(
+			pabyData, srs.cval, &newGeom.cval, C.int(bytes),
+		),
 	).Err()
 }
 
@@ -213,8 +215,10 @@ func CreateFromWKT(wkt string, srs SpatialReference) (Geometry, error) {
 	cString := C.CString(wkt)
 	defer C.free(unsafe.Pointer(cString))
 	var newGeom Geometry
-	return newGeom, C.OGR_G_CreateFromWkt(
-		&cString, srs.cval, &newGeom.cval,
+	return newGeom, OGRErr(
+		C.OGR_G_CreateFromWkt(
+			&cString, srs.cval, &newGeom.cval,
+		),
 	).Err()
 }
 
@@ -323,14 +327,16 @@ func (geom Geometry) Envelope() Envelope {
 // Assign a geometry from well known binary data
 func (geom Geometry) FromWKB(wkb []uint8, bytes int) error {
 	pabyData := (unsafe.Pointer(&wkb[0]))
-	return C.OGR_G_ImportFromWkb(geom.cval, pabyData, C.int(bytes)).Err()
+	return OGRErr(
+		C.OGR_G_ImportFromWkb(geom.cval, pabyData, C.int(bytes)),
+	).Err()
 }
 
 // Convert a geometry to well known binary data
 func (geom Geometry) ToWKB() ([]uint8, error) {
 	b := make([]uint8, geom.WKBSize())
 	cString := (*C.uchar)(unsafe.Pointer(&b[0]))
-	err := C.OGR_G_ExportToWkb(geom.cval, C.OGRwkbByteOrder(C.wkbNDR), cString).Err()
+	err := OGRErr(C.OGR_G_ExportToWkb(geom.cval, C.OGRwkbByteOrder(C.wkbNDR), cString)).Err()
 	return b, err
 }
 
@@ -344,13 +350,13 @@ func (geom Geometry) WKBSize() int {
 func (geom Geometry) FromWKT(wkt string) error {
 	cString := C.CString(wkt)
 	defer C.free(unsafe.Pointer(cString))
-	return C.OGR_G_ImportFromWkt(geom.cval, &cString).Err()
+	return OGRErr(C.OGR_G_ImportFromWkt(geom.cval, &cString)).Err()
 }
 
 // Fetch geometry as WKT
 func (geom Geometry) ToWKT() (string, error) {
 	var p *C.char
-	err := C.OGR_G_ExportToWkt(geom.cval, &p).Err()
+	err := OGRErr(C.OGR_G_ExportToWkt(geom.cval, &p)).Err()
 	wkt := C.GoString(p)
 	return wkt, err
 }
@@ -446,12 +452,12 @@ func (geom Geometry) SetSpatialReference(spatialRef SpatialReference) {
 
 // Apply coordinate transformation to geometry
 func (geom Geometry) Transform(ct CoordinateTransform) error {
-	return C.OGR_G_Transform(geom.cval, ct.cval).Err()
+	return OGRErr(C.OGR_G_Transform(geom.cval, ct.cval)).Err()
 }
 
 // Transform geometry to new spatial reference system
 func (geom Geometry) TransformTo(sr SpatialReference) error {
-	return C.OGR_G_TransformTo(geom.cval, sr.cval).Err()
+	return OGRErr(C.OGR_G_TransformTo(geom.cval, sr.cval)).Err()
 }
 
 // Simplify the geometry
@@ -712,17 +718,17 @@ func (geom Geometry) Geometry(index int) Geometry {
 
 // Add a geometry to a geometry container
 func (geom Geometry) AddGeometry(other Geometry) error {
-	return C.OGR_G_AddGeometry(geom.cval, other.cval).Err()
+	return OGRErr(C.OGR_G_AddGeometry(geom.cval, other.cval)).Err()
 }
 
 // Add a geometry to a geometry container and assign ownership to that container
 func (geom Geometry) AddGeometryDirectly(other Geometry) error {
-	return C.OGR_G_AddGeometryDirectly(geom.cval, other.cval).Err()
+	return OGRErr(C.OGR_G_AddGeometryDirectly(geom.cval, other.cval)).Err()
 }
 
 // Remove a geometry from the geometry container
 func (geom Geometry) RemoveGeometry(index int, delete bool) error {
-	return C.OGR_G_RemoveGeometry(geom.cval, C.int(index), BoolToCInt(delete)).Err()
+	return OGRErr(C.OGR_G_RemoveGeometry(geom.cval, C.int(index), BoolToCInt(delete))).Err()
 }
 
 // Build a polygon / ring from a set of lines
@@ -735,7 +741,7 @@ func (geom Geometry) BuildPolygonFromEdges(autoClose bool, tolerance float64) (G
 		C.double(tolerance),
 		&cErr,
 	)
-	return Geometry{newGeom}, cErr.Err()
+	return Geometry{newGeom}, OGRErr(cErr).Err()
 }
 
 /* -------------------------------------------------------------------- */
@@ -946,7 +952,7 @@ func (fd FeatureDefinition) AddFieldDefinition(fieldDefn FieldDefinition) {
 
 // Delete a field definition from this feature definition
 func (fd FeatureDefinition) DeleteFieldDefinition(index int) error {
-	return C.OGR_FD_DeleteFieldDefn(fd.cval, C.int(index)).Err()
+	return OGRErr(C.OGR_FD_DeleteFieldDefn(fd.cval, C.int(index))).Err()
 }
 
 // Fetch the geometry base type of this feature definition
@@ -1030,12 +1036,12 @@ func (feature Feature) Definition() FeatureDefinition {
 
 // Set feature geometry
 func (feature Feature) SetGeometry(geom Geometry) error {
-	return C.OGR_F_SetGeometry(feature.cval, geom.cval).Err()
+	return OGRErr(C.OGR_F_SetGeometry(feature.cval, geom.cval)).Err()
 }
 
 // Set feature geometry, passing ownership to the feature
 func (feature Feature) SetGeometryDirectly(geom Geometry) error {
-	return C.OGR_F_SetGeometryDirectly(feature.cval, geom.cval).Err()
+	return OGRErr(C.OGR_F_SetGeometryDirectly(feature.cval, geom.cval)).Err()
 }
 
 // Fetch geometry of this feature
@@ -1281,23 +1287,25 @@ func (feature Feature) FID() int {
 
 // Set feature identifier
 func (feature Feature) SetFID(fid int) error {
-	return C.OGR_F_SetFID(feature.cval, C.GIntBig(fid)).Err()
+	return OGRErr(C.OGR_F_SetFID(feature.cval, C.GIntBig(fid))).Err()
 }
 
 // Unimplemented: DumpReadable
 
 // Set one feature from another
 func (this Feature) SetFrom(other Feature, forgiving int) error {
-	return C.OGR_F_SetFrom(this.cval, other.cval, C.int(forgiving)).Err()
+	return OGRErr(C.OGR_F_SetFrom(this.cval, other.cval, C.int(forgiving))).Err()
 }
 
 // Set one feature from another, using field map
 func (this Feature) SetFromWithMap(other Feature, forgiving int, fieldMap []int) error {
-	return C.OGR_F_SetFromWithMap(
-		this.cval,
-		other.cval,
-		C.int(forgiving),
-		(*C.int)(unsafe.Pointer(&fieldMap[0])),
+	return OGRErr(
+		C.OGR_F_SetFromWithMap(
+			this.cval,
+			other.cval,
+			C.int(forgiving),
+			(*C.int)(unsafe.Pointer(&fieldMap[0])),
+		),
 	).Err()
 }
 
@@ -1356,7 +1364,7 @@ func (layer Layer) SetSpatialFilterRect(minX, minY, maxX, maxY float64) {
 func (layer Layer) SetAttributeFilter(filter string) error {
 	cFilter := C.CString(filter)
 	defer C.free(unsafe.Pointer(cFilter))
-	return C.OGR_L_SetAttributeFilter(layer.cval, cFilter).Err()
+	return OGRErr(C.OGR_L_SetAttributeFilter(layer.cval, cFilter)).Err()
 }
 
 // Reset reading to start on the first featre
@@ -1372,7 +1380,7 @@ func (layer Layer) NextFeature() Feature {
 
 // Move read cursor to the provided index
 func (layer Layer) SetNextByIndex(index int) error {
-	return C.OGR_L_SetNextByIndex(layer.cval, C.GIntBig(index)).Err()
+	return OGRErr(C.OGR_L_SetNextByIndex(layer.cval, C.GIntBig(index))).Err()
 }
 
 // Fetch a feature by its index
@@ -1383,17 +1391,17 @@ func (layer Layer) Feature(index int) Feature {
 
 // Rewrite the provided feature
 func (layer Layer) SetFeature(feature Feature) error {
-	return C.OGR_L_SetFeature(layer.cval, feature.cval).Err()
+	return OGRErr(C.OGR_L_SetFeature(layer.cval, feature.cval)).Err()
 }
 
 // Create and write a new feature within a layer
 func (layer Layer) Create(feature Feature) error {
-	return C.OGR_L_CreateFeature(layer.cval, feature.cval).Err()
+	return OGRErr(C.OGR_L_CreateFeature(layer.cval, feature.cval)).Err()
 }
 
 // Delete indicated feature from layer
 func (layer Layer) Delete(index int) error {
-	return C.OGR_L_DeleteFeature(layer.cval, C.GIntBig(index)).Err()
+	return OGRErr(C.OGR_L_DeleteFeature(layer.cval, C.GIntBig(index))).Err()
 }
 
 // Fetch the schema information for this layer
@@ -1416,7 +1424,7 @@ func (layer Layer) FeatureCount(force bool) (count int, ok bool) {
 
 // Fetch the extent of this layer
 func (layer Layer) Extent(force bool) (env Envelope, err error) {
-	err = C.OGR_L_GetExtent(layer.cval, &env.cval, BoolToCInt(force)).Err()
+	err = OGRErr(C.OGR_L_GetExtent(layer.cval, &env.cval, BoolToCInt(force))).Err()
 	return
 }
 
@@ -1430,47 +1438,47 @@ func (layer Layer) TestCapability(capability string) bool {
 
 // Create a new field on a layer
 func (layer Layer) CreateField(fd FieldDefinition, approxOK bool) error {
-	return C.OGR_L_CreateField(layer.cval, fd.cval, BoolToCInt(approxOK)).Err()
+	return OGRErr(C.OGR_L_CreateField(layer.cval, fd.cval, BoolToCInt(approxOK))).Err()
 }
 
 // Delete a field from the layer
 func (layer Layer) DeleteField(index int) error {
-	return C.OGR_L_DeleteField(layer.cval, C.int(index)).Err()
+	return OGRErr(C.OGR_L_DeleteField(layer.cval, C.int(index))).Err()
 }
 
 // Reorder all the fields of a layer
 func (layer Layer) ReorderFields(layerMap []int) error {
-	return C.OGR_L_ReorderFields(layer.cval, (*C.int)(unsafe.Pointer(&layerMap[0]))).Err()
+	return OGRErr(C.OGR_L_ReorderFields(layer.cval, (*C.int)(unsafe.Pointer(&layerMap[0])))).Err()
 }
 
 // Reorder an existing field of a layer
 func (layer Layer) ReorderField(oldIndex, newIndex int) error {
-	return C.OGR_L_ReorderField(layer.cval, C.int(oldIndex), C.int(newIndex)).Err()
+	return OGRErr(C.OGR_L_ReorderField(layer.cval, C.int(oldIndex), C.int(newIndex))).Err()
 }
 
 // Alter the definition of an existing field of a layer
 func (layer Layer) AlterFieldDefn(index int, newDefn FieldDefinition, flags int) error {
-	return C.OGR_L_AlterFieldDefn(layer.cval, C.int(index), newDefn.cval, C.int(flags)).Err()
+	return OGRErr(C.OGR_L_AlterFieldDefn(layer.cval, C.int(index), newDefn.cval, C.int(flags))).Err()
 }
 
 // Begin a transaction on data sources which support it
 func (layer Layer) StartTransaction() error {
-	return C.OGR_L_StartTransaction(layer.cval).Err()
+	return OGRErr(C.OGR_L_StartTransaction(layer.cval)).Err()
 }
 
 // Commit a transaction on data sources which support it
 func (layer Layer) CommitTransaction() error {
-	return C.OGR_L_CommitTransaction(layer.cval).Err()
+	return OGRErr(C.OGR_L_CommitTransaction(layer.cval)).Err()
 }
 
 // Roll back the current transaction on data sources which support it
 func (layer Layer) RollbackTransaction() error {
-	return C.OGR_L_RollbackTransaction(layer.cval).Err()
+	return OGRErr(C.OGR_L_RollbackTransaction(layer.cval)).Err()
 }
 
 // Flush pending changes to the layer
 func (layer Layer) Sync() error {
-	return C.OGR_L_SyncToDisk(layer.cval).Err()
+	return OGRErr(C.OGR_L_SyncToDisk(layer.cval)).Err()
 }
 
 // Fetch the name of the FID column
@@ -1495,7 +1503,7 @@ func (layer Layer) SetIgnoredFields(names []string) error {
 	}
 	cNames[length] = (*C.char)(unsafe.Pointer(nil))
 
-	return C.OGR_L_SetIgnoredFields(layer.cval, (**C.char)(unsafe.Pointer(&cNames[0]))).Err()
+	return OGRErr(C.OGR_L_SetIgnoredFields(layer.cval, (**C.char)(unsafe.Pointer(&cNames[0])))).Err()
 }
 
 // Return the intersection of two layers
@@ -1552,7 +1560,7 @@ func OpenSharedDataSource(name string, update int) DataSource {
 
 // Drop a reference to this datasource and destroy if reference is zero
 func (ds DataSource) Release() error {
-	return C.OGRReleaseDataSource(ds.cval).Err()
+	return OGRErr(C.OGRReleaseDataSource(ds.cval)).Err()
 }
 
 // Return the number of opened data sources
@@ -1612,7 +1620,7 @@ func (ds DataSource) LayerByName(name string) Layer {
 
 // Delete the layer from the data source
 func (ds DataSource) Delete(index int) error {
-	return C.OGR_DS_DeleteLayer(ds.cval, C.int(index)).Err()
+	return OGRErr(C.OGR_DS_DeleteLayer(ds.cval, C.int(index))).Err()
 }
 
 // Fetch the driver that the data source was opened with
@@ -1701,7 +1709,7 @@ func (ds DataSource) ReleaseResultSet(layer Layer) {
 
 // Flush pending changes to the data source
 func (ds DataSource) Sync() error {
-	return C.OGR_DS_SyncToDisk(ds.cval).Err()
+	return OGRErr(C.OGR_DS_SyncToDisk(ds.cval)).Err()
 }
 
 /* -------------------------------------------------------------------- */
@@ -1772,7 +1780,7 @@ func (driver OGRDriver) Copy(source DataSource, name string, options []string) (
 func (driver OGRDriver) Delete(filename string) error {
 	cFilename := C.CString(filename)
 	defer C.free(unsafe.Pointer(cFilename))
-	return C.OGR_Dr_DeleteDataSource(driver.cval, cFilename).Err()
+	return OGRErr(C.OGR_Dr_DeleteDataSource(driver.cval, cFilename)).Err()
 }
 
 // Add a driver to the list of registered drivers

--- a/osr.go
+++ b/osr.go
@@ -39,13 +39,13 @@ func CreateSpatialReference(wkt *string) SpatialReference {
 func (sr SpatialReference) FromWKT(wkt string) error {
 	cString := C.CString(wkt)
 	defer C.free(unsafe.Pointer(cString))
-	return C.OSRImportFromWkt(sr.cval, &cString).Err()
+	return OGRErr(C.OSRImportFromWkt(sr.cval, &cString)).Err()
 }
 
 // Export coordinate system to WKT
 func (sr SpatialReference) ToWKT() (string, error) {
 	var p *C.char
-	err := C.OSRExportToWkt(sr.cval, &p).Err()
+	err := OGRErr(C.OSRExportToWkt(sr.cval, &p)).Err()
 	wkt := C.GoString(p)
 	return wkt, err
 }
@@ -53,21 +53,19 @@ func (sr SpatialReference) ToWKT() (string, error) {
 // Export coordinate system to a nicely formatted WKT string
 func (sr SpatialReference) ToPrettyWKT(simplify bool) (string, error) {
 	var p *C.char
-	err := C.OSRExportToPrettyWkt(
-		sr.cval, &p, BoolToCInt(simplify),
-	).Err()
+	err := OGRErr(C.OSRExportToPrettyWkt(sr.cval, &p, BoolToCInt(simplify))).Err()
 	wkt := C.GoString(p)
 	return wkt, err
 }
 
 // Initialize SRS based on EPSG code
 func (sr SpatialReference) FromEPSG(code int) error {
-	return C.OSRImportFromEPSG(sr.cval, C.int(code)).Err()
+	return OGRErr(C.OSRImportFromEPSG(sr.cval, C.int(code))).Err()
 }
 
 // Initialize SRS based on EPSG code, using EPSG lat/long ordering
 func (sr SpatialReference) FromEPSGA(code int) error {
-	return C.OSRImportFromEPSGA(sr.cval, C.int(code)).Err()
+	return OGRErr(C.OSRImportFromEPSGA(sr.cval, C.int(code))).Err()
 }
 
 // Destroy the spatial reference
@@ -109,20 +107,20 @@ func (sr SpatialReference) Release() {
 
 // Validate spatial reference tokens
 func (sr SpatialReference) Validate() error {
-	return C.OSRValidate(sr.cval).Err()
+	return OGRErr(C.OSRValidate(sr.cval)).Err()
 }
 
 // Import PROJ.4 coordinate string
 func (sr SpatialReference) FromProj4(input string) error {
 	cString := C.CString(input)
 	defer C.free(unsafe.Pointer(cString))
-	return C.OSRImportFromProj4(sr.cval, cString).Err()
+	return OGRErr(C.OSRImportFromProj4(sr.cval, cString)).Err()
 }
 
 // Export coordinate system in PROJ.4 format
 func (sr SpatialReference) ToProj4() (string, error) {
 	var p *C.char
-	err := C.OSRExportToProj4(sr.cval, &p).Err()
+	err := OGRErr(C.OSRExportToProj4(sr.cval, &p)).Err()
 	proj4 := C.GoString(p)
 	return proj4, err
 }
@@ -130,7 +128,7 @@ func (sr SpatialReference) ToProj4() (string, error) {
 // ToProjJSON exports a spatial reference in PROJJSON format
 func (sr SpatialReference) ToProjJSON() (string, error) {
 	var p *C.char
-	err := C.OSRExportToPROJJSON(sr.cval, &p, nil).Err()
+	err := OGRErr(C.OSRExportToPROJJSON(sr.cval, &p, nil)).Err()
 	projjson := C.GoString(p)
 	return projjson, err
 }
@@ -139,7 +137,7 @@ func (sr SpatialReference) ToProjJSON() (string, error) {
 func (sr SpatialReference) FromESRI(input string) error {
 	cString := C.CString(input)
 	defer C.free(unsafe.Pointer(cString))
-	return C.OSRImportFromProj4(sr.cval, cString).Err()
+	return OGRErr(C.OSRImportFromProj4(sr.cval, cString)).Err()
 }
 
 // Import coordinate system from PCI projection definition
@@ -149,22 +147,26 @@ func (sr SpatialReference) FromPCI(proj, units string, params []float64) error {
 	cUnits := C.CString(units)
 	defer C.free(unsafe.Pointer(cUnits))
 
-	return C.OSRImportFromPCI(
-		sr.cval,
-		cProj,
-		cUnits,
-		(*C.double)(unsafe.Pointer(&params[0])),
+	return OGRErr(
+		C.OSRImportFromPCI(
+			sr.cval,
+			cProj,
+			cUnits,
+			(*C.double)(unsafe.Pointer(&params[0])),
+		),
 	).Err()
 }
 
 // Import coordinate system from USGS projection definition
 func (sr SpatialReference) FromUSGS(projsys, zone int, params []float64, datum int) error {
-	return C.OSRImportFromUSGS(
-		sr.cval,
-		C.long(projsys),
-		C.long(zone),
-		(*C.double)(unsafe.Pointer(&params[0])),
-		C.long(datum),
+	return OGRErr(
+		C.OSRImportFromUSGS(
+			sr.cval,
+			C.long(projsys),
+			C.long(zone),
+			(*C.double)(unsafe.Pointer(&params[0])),
+			C.long(datum),
+		),
 	).Err()
 }
 
@@ -172,7 +174,7 @@ func (sr SpatialReference) FromUSGS(projsys, zone int, params []float64, datum i
 func (sr SpatialReference) FromXML(xml string) error {
 	cXml := C.CString(xml)
 	defer C.free(unsafe.Pointer(cXml))
-	return C.OSRImportFromXML(sr.cval, cXml).Err()
+	return OGRErr(C.OSRImportFromXML(sr.cval, cXml)).Err()
 }
 
 // Import coordinate system from ERMapper projection definitions
@@ -184,22 +186,20 @@ func (sr SpatialReference) FromERM(proj, datum, units string) error {
 	cUnits := C.CString(units)
 	defer C.free(unsafe.Pointer(cUnits))
 
-	return C.OSRImportFromERM(sr.cval, cProj, cDatum, cUnits).Err()
+	return OGRErr(C.OSRImportFromERM(sr.cval, cProj, cDatum, cUnits)).Err()
 }
 
 // Import coordinate system from a URL
 func (sr SpatialReference) FromURL(url string) error {
 	cURL := C.CString(url)
 	defer C.free(unsafe.Pointer(cURL))
-	return C.OSRImportFromXML(sr.cval, cURL).Err()
+	return OGRErr(C.OSRImportFromXML(sr.cval, cURL)).Err()
 }
 
 // Export coordinate system in PCI format
 func (sr SpatialReference) ToPCI() (proj, units string, params []float64, errVal error) {
 	var p, u *C.char
-	err := C.OSRExportToPCI(
-		sr.cval, &p, &u, (**C.double)(unsafe.Pointer(&params[0])),
-	).Err()
+	err := OGRErr(C.OSRExportToPCI(sr.cval, &p, &u, (**C.double)(unsafe.Pointer(&params[0])))).Err()
 	header := (*reflect.SliceHeader)(unsafe.Pointer(&params))
 	header.Cap = 17
 	header.Len = 17
@@ -210,12 +210,14 @@ func (sr SpatialReference) ToPCI() (proj, units string, params []float64, errVal
 
 // Export coordinate system to USGS GCTP projection definition
 func (sr SpatialReference) ToUSGS() (proj, zone int, params []float64, datum int, errVal error) {
-	err := C.OSRExportToUSGS(
-		sr.cval,
-		(*C.long)(unsafe.Pointer(&proj)),
-		(*C.long)(unsafe.Pointer(&zone)),
-		(**C.double)(unsafe.Pointer(&params[0])),
-		(*C.long)(unsafe.Pointer(&datum)),
+	err := OGRErr(
+		C.OSRExportToUSGS(
+			sr.cval,
+			(*C.long)(unsafe.Pointer(&proj)),
+			(*C.long)(unsafe.Pointer(&zone)),
+			(**C.double)(unsafe.Pointer(&params[0])),
+			(*C.long)(unsafe.Pointer(&datum)),
+		),
 	).Err()
 
 	header := (*reflect.SliceHeader)(unsafe.Pointer(&params))
@@ -228,7 +230,7 @@ func (sr SpatialReference) ToUSGS() (proj, zone int, params []float64, datum int
 // Export coordinate system in XML format
 func (sr SpatialReference) ToXML() (xml string, errVal error) {
 	var x *C.char
-	err := C.OSRExportToXML(sr.cval, &x, nil).Err()
+	err := OGRErr(C.OSRExportToXML(sr.cval, &x, nil)).Err()
 	defer C.free(unsafe.Pointer(x))
 	return C.GoString(x), err
 }
@@ -236,7 +238,7 @@ func (sr SpatialReference) ToXML() (xml string, errVal error) {
 // Export coordinate system in Mapinfo style CoordSys format
 func (sr SpatialReference) ToMICoordSys() (output string, errVal error) {
 	var x *C.char
-	err := C.OSRExportToMICoordSys(sr.cval, &x).Err()
+	err := OGRErr(C.OSRExportToMICoordSys(sr.cval, &x)).Err()
 	defer C.free(unsafe.Pointer(x))
 	return C.GoString(x), err
 }
@@ -246,12 +248,12 @@ func (sr SpatialReference) ToMICoordSys() (output string, errVal error) {
 
 // Convert in place to ESRI WKT format
 func (sr SpatialReference) MorphToESRI() error {
-	return C.OSRMorphToESRI(sr.cval).Err()
+	return OGRErr(C.OSRMorphToESRI(sr.cval)).Err()
 }
 
 // Convert in place from ESRI WKT format
 func (sr SpatialReference) MorphFromESRI() error {
-	return C.OSRMorphFromESRI(sr.cval).Err()
+	return OGRErr(C.OSRMorphFromESRI(sr.cval)).Err()
 }
 
 // Fetch indicated attribute of named node
@@ -268,14 +270,14 @@ func (sr SpatialReference) SetAttrValue(path, value string) error {
 	defer C.free(unsafe.Pointer(cPath))
 	cValue := C.CString(value)
 	defer C.free(unsafe.Pointer(cValue))
-	return C.OSRSetAttrValue(sr.cval, cPath, cValue).Err()
+	return OGRErr(C.OSRSetAttrValue(sr.cval, cPath, cValue)).Err()
 }
 
 // Set the angular units for the geographic coordinate system
 func (sr SpatialReference) SetAngularUnits(units string, radians float64) error {
 	cUnits := C.CString(units)
 	defer C.free(unsafe.Pointer(cUnits))
-	return C.OSRSetAngularUnits(sr.cval, cUnits, C.double(radians)).Err()
+	return OGRErr(C.OSRSetAngularUnits(sr.cval, cUnits, C.double(radians))).Err()
 }
 
 // Fetch the angular units for the geographic coordinate system
@@ -290,7 +292,7 @@ func (sr SpatialReference) AngularUnits() (string, float64) {
 func (sr SpatialReference) SetLinearUnits(name string, toMeters float64) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	return C.OSRSetLinearUnits(sr.cval, cName, C.double(toMeters)).Err()
+	return OGRErr(C.OSRSetLinearUnits(sr.cval, cName, C.double(toMeters))).Err()
 }
 
 // Set the linear units for the target node
@@ -299,14 +301,14 @@ func (sr SpatialReference) SetTargetLinearUnits(target, units string, toMeters f
 	defer C.free(unsafe.Pointer(cTarget))
 	cUnits := C.CString(units)
 	defer C.free(unsafe.Pointer(cUnits))
-	return C.OSRSetTargetLinearUnits(sr.cval, cTarget, cUnits, C.double(toMeters)).Err()
+	return OGRErr(C.OSRSetTargetLinearUnits(sr.cval, cTarget, cUnits, C.double(toMeters))).Err()
 }
 
 // Set the linear units for the target node and update all existing linear parameters
 func (sr SpatialReference) SetLinearUnitsAndUpdateParameters(name string, toMeters float64) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	return C.OSRSetLinearUnitsAndUpdateParameters(sr.cval, cName, C.double(toMeters)).Err()
+	return OGRErr(C.OSRSetLinearUnitsAndUpdateParameters(sr.cval, cName, C.double(toMeters))).Err()
 }
 
 // Fetch linear projection units
@@ -393,59 +395,61 @@ func (sr SpatialReference) IsSame(other SpatialReference) bool {
 func (sr SpatialReference) SetLocalCS(name string) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	return C.OSRSetLocalCS(sr.cval, cName).Err()
+	return OGRErr(C.OSRSetLocalCS(sr.cval, cName)).Err()
 }
 
 // Set the user visible projected CS name
 func (sr SpatialReference) SetProjectedCS(name string) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	return C.OSRSetProjCS(sr.cval, cName).Err()
+	return OGRErr(C.OSRSetProjCS(sr.cval, cName)).Err()
 }
 
 // Set the user visible geographic CS name
 func (sr SpatialReference) SetGeocentricCS(name string) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	return C.OSRSetGeocCS(sr.cval, cName).Err()
+	return OGRErr(C.OSRSetGeocCS(sr.cval, cName)).Err()
 }
 
 // Set geographic CS based on well known name
 func (sr SpatialReference) SetWellKnownGeographicCS(name string) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	return C.OSRSetWellKnownGeogCS(sr.cval, cName).Err()
+	return OGRErr(C.OSRSetWellKnownGeogCS(sr.cval, cName)).Err()
 }
 
 // Set spatial reference from various text formats
 func (sr SpatialReference) SetFromUserInput(name string) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	return C.OSRSetFromUserInput(sr.cval, cName).Err()
+	return OGRErr(C.OSRSetFromUserInput(sr.cval, cName)).Err()
 }
 
 // Copy geographic CS from another spatial reference
 func (sr SpatialReference) CopyGeographicCSFrom(other SpatialReference) error {
-	return C.OSRCopyGeogCSFrom(sr.cval, other.cval).Err()
+	return OGRErr(C.OSRCopyGeogCSFrom(sr.cval, other.cval)).Err()
 }
 
 // Set the Bursa-Wolf conversion to WGS84
 func (sr SpatialReference) SetTOWGS84(dx, dy, dz, ex, ey, ez, ppm float64) error {
-	return C.OSRSetTOWGS84(
-		sr.cval,
-		C.double(dx),
-		C.double(dy),
-		C.double(dz),
-		C.double(ex),
-		C.double(ey),
-		C.double(ez),
-		C.double(ppm),
+	return OGRErr(
+		C.OSRSetTOWGS84(
+			sr.cval,
+			C.double(dx),
+			C.double(dy),
+			C.double(dz),
+			C.double(ex),
+			C.double(ey),
+			C.double(ez),
+			C.double(ppm),
+		),
 	).Err()
 }
 
 // Fetch the TOWGS84 parameters if available
 func (sr SpatialReference) TOWGS84() (coeff [7]float64, err error) {
-	err = C.OSRGetTOWGS84(sr.cval, (*C.double)(unsafe.Pointer(&coeff[0])), 7).Err()
+	err = OGRErr(C.OSRGetTOWGS84(sr.cval, (*C.double)(unsafe.Pointer(&coeff[0])), 7)).Err()
 	return
 }
 
@@ -456,7 +460,7 @@ func (sr SpatialReference) SetCompoundCS(
 ) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	return C.OSRSetCompoundCS(sr.cval, cName, horizontal.cval, vertical.cval).Err()
+	return OGRErr(C.OSRSetCompoundCS(sr.cval, cName, horizontal.cval, vertical.cval)).Err()
 }
 
 // Set geographic coordinate system
@@ -478,17 +482,19 @@ func (sr SpatialReference) SetGeographicCS(
 	defer C.free(unsafe.Pointer(cPMName))
 	cAngularUnits := C.CString(angularUnits)
 	defer C.free(unsafe.Pointer(cAngularUnits))
-	return C.OSRSetGeogCS(
-		sr.cval,
-		cGeogName,
-		cDatumName,
-		cSpheroidName,
-		C.double(semiMajor),
-		C.double(flattening),
-		cPMName,
-		C.double(offset),
-		cAngularUnits,
-		C.double(toRadians),
+	return OGRErr(
+		C.OSRSetGeogCS(
+			sr.cval,
+			cGeogName,
+			cDatumName,
+			cSpheroidName,
+			C.double(semiMajor),
+			C.double(flattening),
+			cPMName,
+			C.double(offset),
+			cAngularUnits,
+			C.double(toRadians),
+		),
 	).Err()
 }
 
@@ -498,28 +504,28 @@ func (sr SpatialReference) SetVerticalCS(csName, datumName string, datumType int
 	defer C.free(unsafe.Pointer(cCSName))
 	cDatumName := C.CString(datumName)
 	defer C.free(unsafe.Pointer(cDatumName))
-	return C.OSRSetVertCS(sr.cval, cCSName, cDatumName, C.int(datumType)).Err()
+	return OGRErr(C.OSRSetVertCS(sr.cval, cCSName, cDatumName, C.int(datumType))).Err()
 }
 
 // Get spheroid semi-major axis
 func (sr SpatialReference) SemiMajorAxis() (float64, error) {
 	var cErr C.OGRErr
 	axis := C.OSRGetSemiMajor(sr.cval, &cErr)
-	return float64(axis), cErr.Err()
+	return float64(axis), OGRErr(cErr).Err()
 }
 
 // Get spheroid semi-minor axis
 func (sr SpatialReference) SemiMinorAxis() (float64, error) {
 	var cErr C.OGRErr
 	axis := C.OSRGetSemiMinor(sr.cval, &cErr)
-	return float64(axis), cErr.Err()
+	return float64(axis), OGRErr(cErr).Err()
 }
 
 // Get spheroid inverse flattening axis
 func (sr SpatialReference) InverseFlattening() (float64, error) {
 	var cErr C.OGRErr
 	flat := C.OSRGetInvFlattening(sr.cval, &cErr)
-	return float64(flat), cErr.Err()
+	return float64(flat), OGRErr(cErr).Err()
 }
 
 // Sets the authority for a node
@@ -528,7 +534,7 @@ func (sr SpatialReference) SetAuthority(target, authority string, code int) erro
 	defer C.free(unsafe.Pointer(cTarget))
 	cAuthority := C.CString(authority)
 	defer C.free(unsafe.Pointer(cAuthority))
-	return C.OSRSetAuthority(sr.cval, cTarget, cAuthority, C.int(code)).Err()
+	return OGRErr(C.OSRSetAuthority(sr.cval, cTarget, cAuthority, C.int(code))).Err()
 }
 
 // Get the authority code for a node
@@ -551,14 +557,14 @@ func (sr SpatialReference) AuthorityName(target string) string {
 func (sr SpatialReference) SetProjectionByName(name string) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	return C.OSRSetProjection(sr.cval, cName).Err()
+	return OGRErr(C.OSRSetProjection(sr.cval, cName)).Err()
 }
 
 // Set a projection parameter value
 func (sr SpatialReference) SetProjectionParameter(name string, value float64) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	return C.OSRSetProjParm(sr.cval, cName, C.double(value)).Err()
+	return OGRErr(C.OSRSetProjParm(sr.cval, cName, C.double(value))).Err()
 }
 
 // Fetch a projection parameter value
@@ -567,14 +573,14 @@ func (sr SpatialReference) ProjectionParameter(name string, defaultValue float64
 	defer C.free(unsafe.Pointer(cName))
 	var cErr C.OGRErr
 	value := C.OSRGetProjParm(sr.cval, cName, C.double(defaultValue), &cErr)
-	return float64(value), cErr.Err()
+	return float64(value), OGRErr(cErr).Err()
 }
 
 // Set a projection parameter with a normalized value
 func (sr SpatialReference) SetNormalizedProjectionParameter(name string, value float64) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	return C.OSRSetNormProjParm(sr.cval, cName, C.double(value)).Err()
+	return OGRErr(C.OSRSetNormProjParm(sr.cval, cName, C.double(value))).Err()
 }
 
 // Fetch a normalized projection parameter value
@@ -585,12 +591,12 @@ func (sr SpatialReference) NormalizedProjectionParameter(
 	defer C.free(unsafe.Pointer(cName))
 	var cErr C.OGRErr
 	value := C.OSRGetProjParm(sr.cval, cName, C.double(defaultValue), &cErr)
-	return float64(value), cErr.Err()
+	return float64(value), OGRErr(cErr).Err()
 }
 
 // Set UTM projection definition
 func (sr SpatialReference) SetUTM(zone int, north bool) error {
-	return C.OSRSetUTM(sr.cval, C.int(zone), BoolToCInt(north)).Err()
+	return OGRErr(C.OSRSetUTM(sr.cval, C.int(zone), BoolToCInt(north))).Err()
 }
 
 // Get UTM zone information
@@ -602,7 +608,7 @@ func (sr SpatialReference) UTMZone() (zone int, north bool) {
 
 // Set State Plane projection definition
 func (sr SpatialReference) SetStatePlane(zone int, nad83 bool) error {
-	return C.OSRSetStatePlane(sr.cval, C.int(zone), BoolToCInt(nad83)).Err()
+	return OGRErr(C.OSRSetStatePlane(sr.cval, C.int(zone), BoolToCInt(nad83))).Err()
 }
 
 // Set State Plane projection definition
@@ -614,18 +620,20 @@ func (sr SpatialReference) SetStatePlaneWithUnits(
 ) error {
 	cUnitName := C.CString(unitName)
 	defer C.free(unsafe.Pointer(cUnitName))
-	return C.OSRSetStatePlaneWithUnits(
-		sr.cval,
-		C.int(zone),
-		BoolToCInt(nad83),
-		cUnitName,
-		C.double(factor),
+	return OGRErr(
+		C.OSRSetStatePlaneWithUnits(
+			sr.cval,
+			C.int(zone),
+			BoolToCInt(nad83),
+			cUnitName,
+			C.double(factor),
+		),
 	).Err()
 }
 
 // Set EPSG authority info if possible
 func (sr SpatialReference) AutoIdentifyEPSG() error {
-	return C.OSRAutoIdentifyEPSG(sr.cval).Err()
+	return OGRErr(C.OSRAutoIdentifyEPSG(sr.cval)).Err()
 }
 
 // Return true if EPSG feels this coordinate system should be treated as having lat/long coordinate ordering
@@ -641,58 +649,68 @@ func (sr SpatialReference) EPSGTreatsAsLatLong() bool {
 func (sr SpatialReference) SetACEA(
 	stdp1, stdp2, centerLat, centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetACEA(
-		sr.cval,
-		C.double(stdp1),
-		C.double(stdp2),
-		C.double(centerLat),
-		C.double(centerLong),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetACEA(
+			sr.cval,
+			C.double(stdp1),
+			C.double(stdp2),
+			C.double(centerLat),
+			C.double(centerLong),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
 // Set to Azimuthal Equidistant
 func (sr SpatialReference) SetAE(centerLat, centerLong, falseEasting, falseNorthing float64) error {
-	return C.OSRSetAE(
-		sr.cval,
-		C.double(centerLat),
-		C.double(centerLong),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetAE(
+			sr.cval,
+			C.double(centerLat),
+			C.double(centerLong),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
 // Set to Bonne
 func (sr SpatialReference) SetBonne(standardParallel, centralMeridian, falseEasting, falseNorthing float64) error {
-	return C.OSRSetBonne(
-		sr.cval,
-		C.double(standardParallel),
-		C.double(centralMeridian),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetBonne(
+			sr.cval,
+			C.double(standardParallel),
+			C.double(centralMeridian),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
 // Set to Cylindrical Equal Area
 func (sr SpatialReference) SetCEA(stdp1, centralMeridian, falseEasting, falseNorthing float64) error {
-	return C.OSRSetCEA(
-		sr.cval,
-		C.double(stdp1),
-		C.double(centralMeridian),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetCEA(
+			sr.cval,
+			C.double(stdp1),
+			C.double(centralMeridian),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
 // Set to Cassini-Soldner
 func (sr SpatialReference) SetCS(centerLat, centerLong, falseEasting, falseNorthing float64) error {
-	return C.OSRSetCS(
-		sr.cval,
-		C.double(centerLat),
-		C.double(centerLong),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetCS(
+			sr.cval,
+			C.double(centerLat),
+			C.double(centerLong),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -700,25 +718,29 @@ func (sr SpatialReference) SetCS(centerLat, centerLong, falseEasting, falseNorth
 func (sr SpatialReference) SetEC(
 	stdp1, stdp2, centerLat, centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetEC(
-		sr.cval,
-		C.double(stdp1),
-		C.double(stdp2),
-		C.double(centerLat),
-		C.double(centerLong),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetEC(
+			sr.cval,
+			C.double(stdp1),
+			C.double(stdp2),
+			C.double(centerLat),
+			C.double(centerLong),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
 // Set to Eckert I-VI
 func (sr SpatialReference) SetEckert(variation int, centralMeridian, falseEasting, falseNorthing float64) error {
-	return C.OSRSetEckert(
-		sr.cval,
-		C.int(variation),
-		C.double(centralMeridian),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetEckert(
+			sr.cval,
+			C.int(variation),
+			C.double(centralMeridian),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -726,12 +748,14 @@ func (sr SpatialReference) SetEckert(variation int, centralMeridian, falseEastin
 func (sr SpatialReference) SetEquirectangular(
 	centerLat, centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetEquirectangular(
-		sr.cval,
-		C.double(centerLat),
-		C.double(centerLong),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetEquirectangular(
+			sr.cval,
+			C.double(centerLat),
+			C.double(centerLong),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -739,51 +763,59 @@ func (sr SpatialReference) SetEquirectangular(
 func (sr SpatialReference) SetEquirectangularGeneralized(
 	centerLat, centerLong, psuedoStdParallel, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetEquirectangular2(
-		sr.cval,
-		C.double(centerLat),
-		C.double(centerLong),
-		C.double(psuedoStdParallel),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetEquirectangular2(
+			sr.cval,
+			C.double(centerLat),
+			C.double(centerLong),
+			C.double(psuedoStdParallel),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
 // Set to Gall Stereographic
 func (sr SpatialReference) SetGS(centralMeridian, falseEasting, falseNorthing float64) error {
-	return C.OSRSetGS(
-		sr.cval,
-		C.double(centralMeridian),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetGS(
+			sr.cval,
+			C.double(centralMeridian),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
 // Set to Goode Homolosine
 func (sr SpatialReference) SetGH(centralMeridian, falseEasting, falseNorthing float64) error {
-	return C.OSRSetGH(
-		sr.cval,
-		C.double(centralMeridian),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetGH(
+			sr.cval,
+			C.double(centralMeridian),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
 // Set to Interrupted Goode Homolosine
 func (sr SpatialReference) SetIGH() error {
-	return C.OSRSetIGH(sr.cval).Err()
+	return OGRErr(C.OSRSetIGH(sr.cval)).Err()
 }
 
 // Set to GEOS - Geostationary Satellite View
 func (sr SpatialReference) SetGEOS(
 	centralMeridian, satelliteHeight, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetGEOS(
-		sr.cval,
-		C.double(centralMeridian),
-		C.double(satelliteHeight),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetGEOS(
+			sr.cval,
+			C.double(centralMeridian),
+			C.double(satelliteHeight),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -791,13 +823,15 @@ func (sr SpatialReference) SetGEOS(
 func (sr SpatialReference) SetGSTM(
 	centerLat, centerLong, scale, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetGaussSchreiberTMercator(
-		sr.cval,
-		C.double(centerLat),
-		C.double(centerLong),
-		C.double(scale),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetGaussSchreiberTMercator(
+			sr.cval,
+			C.double(centerLat),
+			C.double(centerLong),
+			C.double(scale),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -805,12 +839,14 @@ func (sr SpatialReference) SetGSTM(
 func (sr SpatialReference) SetGnomonic(
 	centerLat, centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetGnomonic(
-		sr.cval,
-		C.double(centerLat),
-		C.double(centerLong),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetGnomonic(
+			sr.cval,
+			C.double(centerLat),
+			C.double(centerLong),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -818,15 +854,17 @@ func (sr SpatialReference) SetGnomonic(
 func (sr SpatialReference) SetHOM(
 	centerLat, centerLong, azimuth, rectToSkew, scale, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetHOM(
-		sr.cval,
-		C.double(centerLat),
-		C.double(centerLong),
-		C.double(azimuth),
-		C.double(rectToSkew),
-		C.double(scale),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetHOM(
+			sr.cval,
+			C.double(centerLat),
+			C.double(centerLong),
+			C.double(azimuth),
+			C.double(rectToSkew),
+			C.double(scale),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -834,16 +872,18 @@ func (sr SpatialReference) SetHOM(
 func (sr SpatialReference) SetHOM2PNO(
 	centerLat, lat1, long1, lat2, long2, scale, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetHOM2PNO(
-		sr.cval,
-		C.double(centerLat),
-		C.double(lat1),
-		C.double(long1),
-		C.double(lat2),
-		C.double(long2),
-		C.double(scale),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetHOM2PNO(
+			sr.cval,
+			C.double(centerLat),
+			C.double(lat1),
+			C.double(long1),
+			C.double(lat2),
+			C.double(long2),
+			C.double(scale),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -851,13 +891,15 @@ func (sr SpatialReference) SetHOM2PNO(
 func (sr SpatialReference) SetIWMPolyconic(
 	lat1, lat2, centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetIWMPolyconic(
-		sr.cval,
-		C.double(lat1),
-		C.double(lat2),
-		C.double(centerLong),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetIWMPolyconic(
+			sr.cval,
+			C.double(lat1),
+			C.double(lat2),
+			C.double(centerLong),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -865,15 +907,17 @@ func (sr SpatialReference) SetIWMPolyconic(
 func (sr SpatialReference) SetKrovak(
 	centerLat, centerLong, azimuth, psuedoStdParallel, scale, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetKrovak(
-		sr.cval,
-		C.double(centerLat),
-		C.double(centerLong),
-		C.double(azimuth),
-		C.double(psuedoStdParallel),
-		C.double(scale),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetKrovak(
+			sr.cval,
+			C.double(centerLat),
+			C.double(centerLong),
+			C.double(azimuth),
+			C.double(psuedoStdParallel),
+			C.double(scale),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -881,12 +925,14 @@ func (sr SpatialReference) SetKrovak(
 func (sr SpatialReference) SetLAEA(
 	centerLat, centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetLAEA(
-		sr.cval,
-		C.double(centerLat),
-		C.double(centerLong),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetLAEA(
+			sr.cval,
+			C.double(centerLat),
+			C.double(centerLong),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -894,14 +940,16 @@ func (sr SpatialReference) SetLAEA(
 func (sr SpatialReference) SetLCC(
 	stdp1, stdp2, centerLat, centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetLCC(
-		sr.cval,
-		C.double(stdp1),
-		C.double(stdp2),
-		C.double(centerLat),
-		C.double(centerLong),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetLCC(
+			sr.cval,
+			C.double(stdp1),
+			C.double(stdp2),
+			C.double(centerLat),
+			C.double(centerLong),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -909,13 +957,15 @@ func (sr SpatialReference) SetLCC(
 func (sr SpatialReference) SetLCC1SP(
 	centerLat, centerLong, scale, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetLCC1SP(
-		sr.cval,
-		C.double(centerLat),
-		C.double(centerLong),
-		C.double(scale),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetLCC1SP(
+			sr.cval,
+			C.double(centerLat),
+			C.double(centerLong),
+			C.double(scale),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -923,14 +973,16 @@ func (sr SpatialReference) SetLCC1SP(
 func (sr SpatialReference) SetLCCB(
 	stdp1, stdp2, centerLat, centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetLCCB(
-		sr.cval,
-		C.double(stdp1),
-		C.double(stdp2),
-		C.double(centerLat),
-		C.double(centerLong),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetLCCB(
+			sr.cval,
+			C.double(stdp1),
+			C.double(stdp2),
+			C.double(centerLat),
+			C.double(centerLong),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -938,12 +990,14 @@ func (sr SpatialReference) SetLCCB(
 func (sr SpatialReference) SetMC(
 	centerLat, centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetMC(
-		sr.cval,
-		C.double(centerLat),
-		C.double(centerLong),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetMC(
+			sr.cval,
+			C.double(centerLat),
+			C.double(centerLong),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -951,13 +1005,15 @@ func (sr SpatialReference) SetMC(
 func (sr SpatialReference) SetMercator(
 	centerLat, centerLong, scale, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetMercator(
-		sr.cval,
-		C.double(centerLat),
-		C.double(centerLong),
-		C.double(scale),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetMercator(
+			sr.cval,
+			C.double(centerLat),
+			C.double(centerLong),
+			C.double(scale),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -965,11 +1021,13 @@ func (sr SpatialReference) SetMercator(
 func (sr SpatialReference) SetMollweide(
 	centralMeridian, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetMollweide(
-		sr.cval,
-		C.double(centralMeridian),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetMollweide(
+			sr.cval,
+			C.double(centralMeridian),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -977,12 +1035,14 @@ func (sr SpatialReference) SetMollweide(
 func (sr SpatialReference) SetNZMG(
 	centerLat, centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetNZMG(
-		sr.cval,
-		C.double(centerLat),
-		C.double(centerLong),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetNZMG(
+			sr.cval,
+			C.double(centerLat),
+			C.double(centerLong),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -990,13 +1050,15 @@ func (sr SpatialReference) SetNZMG(
 func (sr SpatialReference) SetOS(
 	originLat, meridian, scale, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetOS(
-		sr.cval,
-		C.double(originLat),
-		C.double(meridian),
-		C.double(scale),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetOS(
+			sr.cval,
+			C.double(originLat),
+			C.double(meridian),
+			C.double(scale),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -1004,12 +1066,14 @@ func (sr SpatialReference) SetOS(
 func (sr SpatialReference) SetOrthographic(
 	centerLat, centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetOrthographic(
-		sr.cval,
-		C.double(centerLat),
-		C.double(centerLong),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetOrthographic(
+			sr.cval,
+			C.double(centerLat),
+			C.double(centerLong),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -1017,12 +1081,14 @@ func (sr SpatialReference) SetOrthographic(
 func (sr SpatialReference) SetPolyconic(
 	centerLat, centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetPolyconic(
-		sr.cval,
-		C.double(centerLat),
-		C.double(centerLong),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetPolyconic(
+			sr.cval,
+			C.double(centerLat),
+			C.double(centerLong),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -1030,13 +1096,15 @@ func (sr SpatialReference) SetPolyconic(
 func (sr SpatialReference) SetPS(
 	centerLat, centerLong, scale, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetPS(
-		sr.cval,
-		C.double(centerLat),
-		C.double(centerLong),
-		C.double(scale),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetPS(
+			sr.cval,
+			C.double(centerLat),
+			C.double(centerLong),
+			C.double(scale),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -1044,11 +1112,13 @@ func (sr SpatialReference) SetPS(
 func (sr SpatialReference) SetRobinson(
 	centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetRobinson(
-		sr.cval,
-		C.double(centerLong),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetRobinson(
+			sr.cval,
+			C.double(centerLong),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -1056,11 +1126,13 @@ func (sr SpatialReference) SetRobinson(
 func (sr SpatialReference) SetSinusoidal(
 	centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetSinusoidal(
-		sr.cval,
-		C.double(centerLong),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetSinusoidal(
+			sr.cval,
+			C.double(centerLong),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -1068,13 +1140,15 @@ func (sr SpatialReference) SetSinusoidal(
 func (sr SpatialReference) SetStereographic(
 	centerLat, centerLong, scale, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetStereographic(
-		sr.cval,
-		C.double(centerLat),
-		C.double(centerLong),
-		C.double(scale),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetStereographic(
+			sr.cval,
+			C.double(centerLat),
+			C.double(centerLong),
+			C.double(scale),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -1082,12 +1156,14 @@ func (sr SpatialReference) SetStereographic(
 func (sr SpatialReference) SetSOC(
 	latitudeOfOrigin, centralMeridian, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetSOC(
-		sr.cval,
-		C.double(latitudeOfOrigin),
-		C.double(centralMeridian),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetSOC(
+			sr.cval,
+			C.double(latitudeOfOrigin),
+			C.double(centralMeridian),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -1095,13 +1171,15 @@ func (sr SpatialReference) SetSOC(
 func (sr SpatialReference) SetTM(
 	centerLat, centerLong, scale, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetTM(
-		sr.cval,
-		C.double(centerLat),
-		C.double(centerLong),
-		C.double(scale),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetTM(
+			sr.cval,
+			C.double(centerLat),
+			C.double(centerLong),
+			C.double(scale),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -1111,14 +1189,16 @@ func (sr SpatialReference) SetTMVariant(
 ) error {
 	cName := C.CString(variantName)
 	defer C.free(unsafe.Pointer(cName))
-	return C.OSRSetTMVariant(
-		sr.cval,
-		cName,
-		C.double(centerLat),
-		C.double(centerLong),
-		C.double(scale),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetTMVariant(
+			sr.cval,
+			cName,
+			C.double(centerLat),
+			C.double(centerLong),
+			C.double(scale),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -1126,12 +1206,14 @@ func (sr SpatialReference) SetTMVariant(
 func (sr SpatialReference) SetTMG(
 	centerLat, centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetTMG(
-		sr.cval,
-		C.double(centerLat),
-		C.double(centerLong),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetTMG(
+			sr.cval,
+			C.double(centerLat),
+			C.double(centerLong),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -1139,13 +1221,15 @@ func (sr SpatialReference) SetTMG(
 func (sr SpatialReference) SetTMSO(
 	centerLat, centerLong, scale, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetTMSO(
-		sr.cval,
-		C.double(centerLat),
-		C.double(centerLong),
-		C.double(scale),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetTMSO(
+			sr.cval,
+			C.double(centerLat),
+			C.double(centerLong),
+			C.double(scale),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 
@@ -1153,11 +1237,13 @@ func (sr SpatialReference) SetTMSO(
 func (sr SpatialReference) SetVDG(
 	centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return C.OSRSetVDG(
-		sr.cval,
-		C.double(centerLong),
-		C.double(falseEasting),
-		C.double(falseNorthing),
+	return OGRErr(
+		C.OSRSetVDG(
+			sr.cval,
+			C.double(centerLong),
+			C.double(falseEasting),
+			C.double(falseNorthing),
+		),
 	).Err()
 }
 


### PR DESCRIPTION
 - Added OGRErr and CPLErr types to properly wrap the underlying C error types rather than reference the C errors directly. This allows methods to be defined on those types, which was a bug fix in Go 1.21
 - Added type cast to all usages of the old C types