### PR TITLE
Fixed issue with Linear Units and added FromURN

### DIFF
--- a/osr.go
+++ b/osr.go
@@ -42,6 +42,11 @@ func (sr SpatialReference) FromWKT(wkt string) error {
 	return OGRErr(C.OSRImportFromWkt(sr.cval, &cString)).Err()
 }
 
+// Initialize SRS based on URN string
+func (sr SpatialReference) FromURN(urn string) error {
+	return sr.SetFromUserInput(urn)
+}
+
 // Export coordinate system to WKT
 func (sr SpatialReference) ToWKT() (string, error) {
 	var p *C.char
@@ -315,7 +320,6 @@ func (sr SpatialReference) SetLinearUnitsAndUpdateParameters(name string, toMete
 func (sr SpatialReference) LinearUnits() (string, float64) {
 	var x *C.char
 	factor := C.OSRGetLinearUnits(sr.cval, &x)
-	defer C.free(unsafe.Pointer(x))
 	return C.GoString(x), float64(factor)
 }
 
@@ -325,7 +329,6 @@ func (sr SpatialReference) TargetLinearUnits(target string) (string, float64) {
 	defer C.free(unsafe.Pointer(cTarget))
 	var x *C.char
 	factor := C.OSRGetTargetLinearUnits(sr.cval, cTarget, &x)
-	defer C.free(unsafe.Pointer(x))
 	return C.GoString(x), float64(factor)
 }
 

--- a/osr_test.go
+++ b/osr_test.go
@@ -17,3 +17,20 @@ func TestToProjJSON(t *testing.T) {
 	assert.NoError(t, err)
 	fmt.Println(pj)
 }
+
+func TestLinearUnits(t *testing.T) {
+	sr := gdal.CreateSpatialReference(nil)
+	err := sr.FromURN("urn:ogc:def:crs:EPSG:6.18.3:3857")
+	assert.NoError(t, err)
+
+	units, value := sr.LinearUnits()
+	assert.NoError(t, err)
+	assert.Equal(t, "metre", units)
+	assert.Equal(t, 1.0, value)
+
+	units, value = sr.TargetLinearUnits("PROJCS")
+	assert.NoError(t, err)
+	assert.Equal(t, "metre", units)
+	assert.Equal(t, 1.0, value)
+
+}


### PR DESCRIPTION
## Description

- I was having some some segfaults while testing my WMTS stuff and calling LinearUnits. Based on the [docs](https://gdal.org/api/ogrspatialref.html#_CPPv4NK19OGRSpatialReference14GetLinearUnitsEPPc) I think that the pointer we are giving the function is being overwritten by a pointer to something in C land, and then we are trying to free it. This shouldn't be a memory leak as long as the SR is destroyed.
- Added a from URN convenience function. I spent some time looking for it because it is listed in gdal docs, but it turns out there is no binding for it because `SetFromUserInput` does the same thing

## Testing

unit testing
